### PR TITLE
update path in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,4 +2,4 @@
 applications:
 - name: pridehack-digital
   buildpack: staticfile_buildpack
-  path: /dist
+  path: dist/


### PR DESCRIPTION
`/dist` is looking in root. `dist/` looks in the current location and is probably why this was not working in the past